### PR TITLE
feat: Create VS Code extension to remove Dart log statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,144 +1,67 @@
+# Dart Log Remover
+
+## Description
+
+Quickly remove `print()` and `dart:developer log()` statements from your Dart code. This extension helps clean up your codebase by removing debugging logs before committing or publishing your code.
+
+## Features
+
+*   **Remove Log Statements:** Deletes all found `print(...);` and `log(...);` statements from the currently active Dart file.
+*   **Dry-run Mode:** Preview which log statements would be removed without actually modifying the file. The list of logs is shown in an Output Channel.
+*   **Supported Log Types:**
+    *   `print(...);` statements.
+    *   `log(...);` statements from the `dart:developer` package.
+
+## Installation
+
+Currently, this extension is intended for local development and testing. To use it:
+
+1.  **Clone the repository** (or ensure you have the source code).
+2.  **Install dependencies:** Open the project folder in your terminal and run `npm install`.
+3.  **Compile the extension:** Run `npm run compile` (or `npm run watch` for automatic compilation on changes).
+4.  **Open in VS Code:** Open the extension's project folder in VS Code.
+5.  **Run the Extension (Development Host):**
+    *   Press `F5` or go to "Run" -> "Start Debugging". This will open a new VS Code window (the "Extension Development Host") with the extension loaded.
+    *   Open any Dart project or file in this new window to test the extension.
+
+Alternatively, to install it more permanently for local use (sideloading):
+
+1.  **Package the extension:**
+    *   You'll need the `vsce` (Visual Studio Code Extensions) packaging tool. If you don't have it, install it globally: `npm install -g vsce`
+    *   In the root directory of the extension project, run: `vsce package`
+    *   This will create a `.vsix` file (e.g., `dart-log-remover-0.0.1.vsix`).
+2.  **Install from VSIX:**
+    *   In VS Code, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`).
+    *   Type "Extensions: Install from VSIX..." and select it.
+    *   Locate the `.vsix` file you created and select it.
+    *   Reload VS Code when prompted.
+
+## Usage
+
+### Remove Log Statements
+
+1.  Open a Dart file (`.dart`) in VS Code.
+2.  Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`).
+3.  Type "Remove Log Statements" and select the command `Dart Log Remover: Remove Log Statements`.
+4.  If log statements are found, they will be removed from the file. An information message will confirm the number of statements removed.
+
+### Dry-run: Show Logs to be Removed
+
+1.  Open a Dart file (`.dart`) in VS Code.
+2.  Open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`).
+3.  Type "Dry-run: Show Logs to be Removed" and select the command `Dart Log Remover: Dry-run: Show Logs to be Removed`.
+4.  The extension will scan the file for log statements.
+5.  The results will be displayed in the Output panel, under a channel named "Dart Log Remover". An information message will also appear, indicating how many potential logs were found.
+
+## Known Issues/Limitations
+
+*   **Regex-Based Matching:** The current implementation uses regular expressions to identify log statements. While designed to cover common cases, it may not perfectly handle all complex or unusually formatted multiline log statements. For example, a `print` statement where the closing `);` is on a much later line and involves complex string concatenation might not be fully captured.
+*   **No Configuration:** There are currently no settings to customize which types of logs are removed (e.g., only `print`, or only `log`).
+
+## Contributing
+
+Contributions are welcome! If you have suggestions for improvements or find any issues, please feel free to open an issue or submit a pull request on the project's repository.
 
 ---
 
-# 🔧 Log Removal  
-
-**Log Removal** is a command-line tool designed to clean up Dart/Flutter projects by removing unwanted log statements, such as `print`, `debugPrint`, `logger`, and other custom log patterns.  
-
-This tool allows users to select predefined log patterns or add their custom patterns using regular expressions (regex). It can be installed globally for seamless usage across multiple projects.  
-
----
-
-## ✨ Key Features  
-
-- **Global Usage**: Install once and use it in all your Dart/Flutter projects.  
-- **Multi-select**: Remove multiple log patterns in one go.  
-- **Custom Patterns**: Add custom log patterns with regex.  
-- **High Compatibility**: Specifically built for Dart and Flutter projects.  
-- **User-Friendly**: A simple text-based interface to select files or folders for processing.  
-
----
-
-## ⚙️ Installation  
-
-### 1. Global Installation  
-
-Install **Log Removal** globally to use it across all your projects with the following command:  
-
-```bash
-dart pub global activate log_removal
-```  
-
-After installation, the `log_removal` command will be available globally in your terminal, ready to use in any project directory.  
-
-### 2. Local Installation (Optional)  
-
-If you want to use **Log Removal** in a specific project, add it as a dependency:  
-
-```yaml
-dependencies:
-  log_removal: <latest_version>
-```  
-
-Then, run it using the following command within the project:  
-
-```bash
-dart run log_removal
-```  
-
----
-
-## 🚀 How to Use  
-
-### 1. Running the Program  
-
-Once installed, run the program with:  
-
-```bash
-log_removal
-```  
-
-### 2. Select an Operation  
-
-Choose one of the following options:  
-- **Specific File**: Clean logs from a specific file.  
-- **Specific Folder**: Clean logs from a specific folder.  
-- **Entire Project**: Clean logs from the entire project.  
-
-### 3. Choose Log Patterns  
-
-The program will display a list of log patterns to remove, such as:  
-- `print(...)`  
-- `debugPrint(...)`  
-- `logger.*(...)`  
-- `logMessage(...)`  
-
-You can select multiple patterns or add a custom pattern using regex.  
-
-### 4. Cleaning Results  
-
-After processing, the program will display:  
-- The number of files processed.  
-- The number of logs removed.  
-
----
-
-## 📂 Example  
-
-### Running the CLI  
-
-```bash
-$ log_removal
-🔧 Welcome to Log Removal!
-Let's clean up your project from unwanted logs. 🚀
-
-📂 Select a folder from the current directory:
-✅ Folder selected: /path/to/project
-
-Choose log patterns to remove:
-[0] print(...)
-[1] debugPrint(...)
-[2] logger.*(...)
-[3] logMessage(...)
-[4] Custom pattern
-Select options (e.g., 0,1,3): 0,1,4
-
-🔧 Enter your custom regex pattern:
-^\s*customLog\(.*\);\s*$
-
-✅ Custom pattern added.
-✅ Log removal completed.
-📁 Files Processed: 5
-```  
-
----
-
-## 🛠 Supported Log Patterns  
-
-The predefined log patterns include:  
-1. **`print(...)`**: Matches `print()` statements.  
-2. **`debugPrint(...)`**: Matches `debugPrint()` statements.  
-3. **`logger.*(...)`**: Matches logging functions like `logger.d()` or `logger.e()`.  
-4. **`logMessage(...)`**: Matches custom log functions like `logMessage()`.  
-
-In addition to these, you can add custom log patterns using name of log to handle unique logging formats in your projects.  
-
----
-
-## 🤝 Contributing  
-
-Contributions are welcome!  
-To contribute:  
-1. **Fork** this repository.  
-2. Create a new branch for your feature or fix.  
-3. Submit a pull request with a clear description of your changes.  
-
----
-
-## 📄 License  
-
-This project is licensed under the [MIT License](LICENSE).  
-
----  
-
-This version is cleaner, more concise, and user-friendly. 🎉
+_This README was generated for the Dart Log Remover VS Code extension._

--- a/package.json
+++ b/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "dart-log-remover",
+  "displayName": "Dart Log Remover",
+  "description": "A VS Code extension to remove logging statements from Dart code.",
+  "version": "0.0.1",
+  "publisher": "yourname",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:dart-log-remover.removeLogs",
+    "onCommand:dart-log-remover.dryRunRemoveLogs"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "dart-log-remover.removeLogs",
+        "title": "Remove Log Statements"
+      },
+      {
+        "command": "dart-log-remover.dryRunRemoveLogs",
+        "title": "Dry-run: Show Logs to be Removed"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "vscode-test"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "@types/glob": "^8.1.0",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "20.2.5",
+    "eslint": "^8.41.0",
+    "glob": "^8.1.0",
+    "mocha": "^10.2.0",
+    "typescript": "^5.1.3",
+    "@vscode/test-cli": "^0.0.6",
+    "@vscode/test-electron": "^2.3.2"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,144 @@
+import * as vscode from 'vscode';
+
+// Regular expression to find 'print(...);' statements.
+// This regex handles:
+// - Optional whitespace before 'print'
+// - 'print' keyword
+// - Optional whitespace after 'print'
+// - Opening parenthesis '('
+// - Any characters inside the parentheses (non-greedy match)
+// - Closing parenthesis ')'
+// - Optional whitespace before semicolon
+// - Semicolon ';'
+// - Captures the entire line.
+export const PRINT_LOG_REGEX = /^\s*print\s*\([\s\S]*?\)\s*;\s*$/gm;
+
+// Regular expression to find 'log(...);' statements from dart:developer.
+// This regex handles:
+// - Optional whitespace before 'log'
+// - 'log' keyword
+// - Optional whitespace after 'log'
+// - Opening parenthesis '('
+// - Any characters inside the parentheses (non-greedy match)
+// - Closing parenthesis ')'
+// - Optional whitespace before semicolon
+// - Semicolon ';'
+// - Captures the entire line.
+export const LOG_FUNCTION_REGEX = /^\s*log\s*\([\s\S]*?\)\s*;\s*$/gm;
+
+export function activate(context: vscode.ExtensionContext) {
+  console.log('Congratulations, your extension "dart-log-remover" is now active!');
+
+  let disposable = vscode.commands.registerCommand('dart-log-remover.removeLogs', () => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+      vscode.window.showInformationMessage('No active text editor found.');
+      return;
+    }
+
+    const document = editor.document;
+    const documentText = document.getText();
+    let edits: vscode.TextEdit[] = [];
+    let matchesFound = 0;
+
+    // Combine regexes for a single pass, or iterate twice
+    const combinedRegex = new RegExp(
+      `(${PRINT_LOG_REGEX.source})|(${LOG_FUNCTION_REGEX.source})`,
+      'gm'
+    );
+
+    let match;
+    while ((match = combinedRegex.exec(documentText)) !== null) {
+      const matchIndex = match.index;
+      const startPosition = document.positionAt(matchIndex);
+      const endPosition = document.positionAt(matchIndex + match[0].length);
+      const range = new vscode.Range(startPosition, endPosition);
+      
+      // To remove the entire line, we extend the range to include the line break.
+      // However, be careful not to remove the line break of the *next* line if the log is the last content on its line.
+      // It's generally safer to just remove the matched text itself, 
+      // but if the goal is to remove the whole line, we need to find the line's full range.
+      const line = document.lineAt(startPosition.line);
+      
+      // Check if the match is the only content on the line (ignoring whitespace)
+      if (line.text.trim() === match[0].trim()) {
+        // If it's the only content, remove the whole line including the line break
+        const lineEndPosition = document.lineAt(startPosition.line).range.end;
+        // If it's not the last line, extend to the start of the next line to remove the line break
+        if (startPosition.line < document.lineCount - 1) {
+          edits.push(vscode.TextEdit.delete(new vscode.Range(line.range.start, document.lineAt(startPosition.line + 1).range.start)));
+        } else {
+          // If it's the last line, just delete the line content
+          edits.push(vscode.TextEdit.delete(line.range));
+        }
+      } else {
+        // If there's other content on the line, just delete the match
+        edits.push(vscode.TextEdit.delete(range));
+      }
+      matchesFound++;
+    }
+
+    if (matchesFound === 0) {
+      vscode.window.showInformationMessage('No Dart log statements found to remove.');
+      return;
+    }
+
+    editor.edit(editBuilder => {
+      edits.forEach(edit => editBuilder.delete(edit.range)); // editBuilder.replace(edit.range, edit.newText) if we were replacing
+    }).then(success => {
+      if (success) {
+        vscode.window.showInformationMessage(`Removed ${matchesFound} log statement(s).`);
+      } else {
+        vscode.window.showErrorMessage('Failed to remove log statements.');
+      }
+    });
+  });
+
+  context.subscriptions.push(disposable);
+
+  let dryRunDisposable = vscode.commands.registerCommand('dart-log-remover.dryRunRemoveLogs', () => {
+    const editor = vscode.window.activeTextEditor;
+
+    if (!editor) {
+      vscode.window.showInformationMessage('No active text editor found.');
+      return;
+    }
+
+    const document = editor.document;
+    const documentText = document.getText();
+    let logsFound: { lineNumber: number, content: string }[] = [];
+
+    const combinedRegex = new RegExp(
+      `(${PRINT_LOG_REGEX.source})|(${LOG_FUNCTION_REGEX.source})`,
+      'gm'
+    );
+
+    let match;
+    while ((match = combinedRegex.exec(documentText)) !== null) {
+      const matchIndex = match.index;
+      const startPosition = document.positionAt(matchIndex);
+      const line = document.lineAt(startPosition.line);
+      logsFound.push({ lineNumber: line.lineNumber + 1, content: line.text.trim() });
+    }
+
+    const outputChannel = vscode.window.createOutputChannel("Dart Log Remover");
+    outputChannel.clear(); // Clear previous dry-run results
+
+    if (logsFound.length === 0) {
+      outputChannel.appendLine('No Dart log statements found.');
+      vscode.window.showInformationMessage('No Dart log statements found to remove.');
+    } else {
+      outputChannel.appendLine(`Found ${logsFound.length} log statement(s) that would be removed:\n`);
+      logsFound.forEach(log => {
+        outputChannel.appendLine(`Line ${log.lineNumber}: ${log.content}`);
+      });
+      vscode.window.showInformationMessage(`Found ${logsFound.length} log statement(s). See the "Dart Log Remover" output channel for details.`);
+    }
+    outputChannel.show(true); // true to preserve focus on the editor
+  });
+
+  context.subscriptions.push(dryRunDisposable);
+}
+
+export function deactivate() {}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+import { runTests } from '@vscode/test-electron';
+
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
+
+    // The path to the extension test script
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, './suite/index');
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (err) {
+    console.error('Failed to run tests');
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,0 +1,273 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { PRINT_LOG_REGEX, LOG_FUNCTION_REGEX } from '../../extension'; // Import actual regexes
+
+// Helper function to convert string offsets to vscode.Position
+function positionAt(text: string, offset: number): vscode.Position {
+	let line = 0;
+	let character = 0;
+	for (let i = 0; i < offset; i++) {
+		if (text[i] === '\n') {
+			line++;
+			character = 0;
+		} else {
+			character++;
+		}
+	}
+	return new vscode.Position(line, character);
+}
+
+// Helper function to get line at a certain offset
+function lineAt(text: string, offsetOrLine: number): { text: string, range: vscode.Range, lineNumber: number, rangeIncludingLineBreak: vscode.Range } {
+    let lineContent: string;
+    let lineNum: number;
+    let lineStartOffset: number;
+    let lineEndOffset: number;
+    let nextLineStartOffset: number | undefined = undefined;
+
+    if (typeof offsetOrLine === 'number' && offsetOrLine >= 0 && offsetOrLine < text.split('\n').length) { // it's a line number
+        lineNum = offsetOrLine;
+        const lines = text.split('\n');
+        lineContent = lines[lineNum];
+        lineStartOffset = 0;
+        for(let i=0; i < lineNum; i++) {
+            lineStartOffset += lines[i].length + 1; // +1 for \n
+        }
+        lineEndOffset = lineStartOffset + lineContent.length;
+        if (lineNum < lines.length - 1) {
+            nextLineStartOffset = lineEndOffset + 1; // +1 for \n
+        }
+
+    } else if (typeof offsetOrLine === 'number') { // it's an offset
+        const lines = text.split('\n');
+        let currentOffset = 0;
+        let found = false;
+        for (let i = 0; i < lines.length; i++) {
+            const lineLength = lines[i].length;
+            if (offsetOrLine >= currentOffset && offsetOrLine <= currentOffset + lineLength) {
+                lineNum = i;
+                lineContent = lines[i];
+                lineStartOffset = currentOffset;
+                lineEndOffset = currentOffset + lineLength;
+                if (i < lines.length - 1) {
+                    nextLineStartOffset = lineEndOffset + 1;
+                }
+                found = true;
+                break;
+            }
+            currentOffset += lineLength + 1; // +1 for \n
+        }
+        if (!found) throw new Error("Offset out of bounds");
+    } else {
+        throw new Error("Invalid argument for lineAt");
+    }
+
+
+    const startPos = positionAt(text, lineStartOffset);
+    const endPos = positionAt(text, lineEndOffset);
+    let endIncludingLineBreak = endPos;
+    if (nextLineStartOffset !== undefined) {
+        endIncludingLineBreak = positionAt(text, nextLineStartOffset);
+    }
+
+
+    return {
+        text: lineContent,
+        range: new vscode.Range(startPos, endPos),
+        lineNumber: lineNum,
+        rangeIncludingLineBreak: new vscode.Range(startPos, endIncludingLineBreak)
+    };
+}
+
+
+// This function replicates the core logic of finding matches and determining their removal ranges.
+// It does not depend on vscode.window.activeTextEditor or other UI elements.
+function getTestEdits(documentText: string): vscode.TextEdit[] {
+	let edits: vscode.TextEdit[] = [];
+	const combinedRegex = new RegExp(
+		`(${PRINT_LOG_REGEX.source})|(${LOG_FUNCTION_REGEX.source})`,
+		'gm' // Ensure 'g' flag is here, 'm' for multiline ^ $ matching
+	);
+
+	let match;
+	while ((match = combinedRegex.exec(documentText)) !== null) {
+		const matchIndex = match.index;
+		const matchText = match[0];
+		const startPosition = positionAt(documentText, matchIndex);
+		const endPosition = positionAt(documentText, matchIndex + matchText.length);
+		let range = new vscode.Range(startPosition, endPosition);
+
+		const line = lineAt(documentText, startPosition.line);
+
+		if (line.text.trim() === matchText.trim()) {
+			// If it's the only content, remove the whole line including the line break
+            if (startPosition.line < documentText.split('\n').length - 1) {
+                 range = new vscode.Range(line.range.start, lineAt(documentText, startPosition.line + 1).range.start);
+            } else {
+                range = line.range;
+            }
+		}
+		// Else, just the matched range is fine (already set)
+		edits.push(vscode.TextEdit.delete(range));
+	}
+	return edits;
+}
+
+
+suite('Extension Test Suite', () => {
+	vscode.window.showInformationMessage('Start all tests.');
+
+	suite('Regular Expression Tests', () => {
+		test('PRINT_LOG_REGEX should match valid print statements', () => {
+			const validPrints = [
+				"print('hello');",
+				"  print('hello');  ",
+				"print ( 'hello' ) ;",
+				"print('hello ${name}');",
+				"print(object.toString());",
+				"print(1 + 2);",
+				"print(\n  'multiline'\n);"
+			];
+			validPrints.forEach(s => {
+				PRINT_LOG_REGEX.lastIndex = 0; // Reset regex state
+				assert.ok(PRINT_LOG_REGEX.test(s), `Failed for: ${s}`);
+			});
+		});
+
+		test('PRINT_LOG_REGEX should not match invalid print statements', () => {
+			const invalidPrints = [
+				"Print('hello');", // Case-sensitive
+				"print 'hello';",   // Missing parentheses
+				"print('hello')",   // Missing semicolon
+				"// print('hello');", // Commented out
+				"myprint('hello');" // Different function name
+			];
+			invalidPrints.forEach(s => {
+				PRINT_LOG_REGEX.lastIndex = 0;
+				assert.strictEqual(PRINT_LOG_REGEX.test(s), false, `Incorrectly matched: ${s}`);
+			});
+		});
+
+		test('LOG_FUNCTION_REGEX should match valid log statements', () => {
+			const validLogs = [
+				"log('message');",
+				"  log('message', level: 900, error: e);  ",
+				"log ( 'message' ) ;",
+				"log('message ${var}');",
+				"log(object.toMap(), name: 'MyObject');",
+				"log(\n  'multiline message'\n);"
+			];
+			validLogs.forEach(s => {
+				LOG_FUNCTION_REGEX.lastIndex = 0;
+				assert.ok(LOG_FUNCTION_REGEX.test(s), `Failed for: ${s}`);
+			});
+		});
+
+		test('LOG_FUNCTION_REGEX should not match invalid log statements', () => {
+			const invalidLogs = [
+				"Log('message');", // Case-sensitive
+				"log 'message';",   // Missing parentheses
+				"log('message')",   // Missing semicolon
+				"// log('message');", // Commented out
+				"mylog('message');" // Different function name
+			];
+			invalidLogs.forEach(s => {
+				LOG_FUNCTION_REGEX.lastIndex = 0;
+				assert.strictEqual(LOG_FUNCTION_REGEX.test(s), false, `Incorrectly matched: ${s}`);
+			});
+		});
+	});
+
+	suite('TextEdit Generation Logic', () => {
+		test('Should generate TextEdit to delete full line for single log statement', () => {
+			const docContent = "print('hello');";
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 1, "Should find one edit");
+			const edit = edits[0];
+			// Expects deletion from start of line 0 to start of line 1 (or end of doc if last line)
+			const expectedRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, docContent.length));
+            // If it's the only line, the range is the line itself. If not, it extends to the start of the next line.
+            // Our getTestEdits logic for single/last line: range = line.range;
+            // For multiple lines: range = new vscode.Range(line.range.start, lineAt(documentText, startPosition.line + 1).range.start);
+            // Since docContent has no newline, it's treated as the "last line" case.
+			assert.deepStrictEqual(edit.range, expectedRange, "Range should cover the entire line content");
+		});
+
+        test('Should generate TextEdit to delete full line for log statement ending document', () => {
+			const docContent = "void main() {}\nprint('hello');";
+            const lines = docContent.split('\n');
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 1, "Should find one edit");
+			const edit = edits[0];
+            const expectedRange = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, lines[1].length));
+			assert.deepStrictEqual(edit.range, expectedRange, "Range should cover the entire last line");
+		});
+
+
+		test('Should generate TextEdit to delete full line (including newline) for log statement followed by another line', () => {
+			const docContent = "print('hello');\nint x = 5;";
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 1, "Should find one edit");
+			const edit = edits[0];
+			// Expects deletion from start of line 0 to start of line 1
+			const expectedRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(1, 0));
+			assert.deepStrictEqual(edit.range, expectedRange, "Range should cover line 0 and its newline");
+		});
+
+		test('Should generate TextEdit to delete only statement for log on line with other code (prefix)', () => {
+			const docContent = "int x = 5; print('debug');";
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 1, "Should find one edit");
+			const edit = edits[0];
+			const expectedRange = new vscode.Range(positionAt(docContent, 12), positionAt(docContent, 12 + "print('debug');".length));
+			assert.deepStrictEqual(edit.range, expectedRange, "Range should cover only the print statement");
+		});
+
+		test('Should generate TextEdit to delete only statement for log on line with other code (suffix)', () => {
+			const docContent = "print('debug'); int x = 5;";
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 1, "Should find one edit");
+			const edit = edits[0];
+			const expectedRange = new vscode.Range(positionAt(docContent, 0), positionAt(docContent, "print('debug');".length));
+			assert.deepStrictEqual(edit.range, expectedRange, "Range should cover only the print statement");
+		});
+		
+		test('Should generate multiple TextEdits for multiple log lines', () => {
+			const docContent = "print('log1');\nint y=0;\nlog('log2');";
+            const lines = docContent.split('\n');
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 2, "Should find two edits");
+
+			const expectedRange1 = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(1, 0)); // Full line for print('log1');
+			assert.deepStrictEqual(edits[0].range, expectedRange1, "Range for first log is incorrect");
+			
+			const expectedRange2 = new vscode.Range(new vscode.Position(2, 0), new vscode.Position(2, lines[2].length));    // Full line for log('log2');
+			assert.deepStrictEqual(edits[1].range, expectedRange2, "Range for second log is incorrect");
+		});
+
+		test('Should generate no TextEdits for document with no log lines', () => {
+			const docContent = "int x = 5;\nString y = 'test';";
+			const edits = getTestEdits(docContent);
+			assert.strictEqual(edits.length, 0, "Should find no edits");
+		});
+
+        test('Should handle log statement with preceding whitespace correctly', () => {
+            const docContent = "    print('indented log');\nint x = 0;";
+            const edits = getTestEdits(docContent);
+            assert.strictEqual(edits.length, 1, "Should find one edit for indented log");
+            const expectedRange = new vscode.Range(new vscode.Position(0,0), new vscode.Position(1,0)); // Full line delete
+            assert.deepStrictEqual(edits[0].range, expectedRange, "Range for indented log is incorrect");
+        });
+
+        test('Should handle log statement with trailing code on the same line', () => {
+            const docContent = "print('log here'); var a = 1; // comment";
+            const edits = getTestEdits(docContent);
+            assert.strictEqual(edits.length, 1);
+            const expectedRange = new vscode.Range(positionAt(docContent,0), positionAt(docContent, "print('log here');".length));
+            assert.deepStrictEqual(edits[0].range, expectedRange, "Should only remove the log statement part");
+        });
+
+	});
+});

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
+
+export function run(): Promise<void> {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true
+  });
+
+  const testsRoot = path.resolve(__dirname, '..');
+
+  return new Promise((c, e) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return e(err);
+      }
+
+      // Add files to the test suite
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+      try {
+        // Run the mocha test
+        mocha.run(failures => {
+          if (failures > 0) {
+            e(new Error(`${failures} tests failed.`));
+          } else {
+            c();
+          }
+        });
+      } catch (err) {
+        console.error(err);
+        e(err);
+      }
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "out",
+    "lib": [
+      "ES2020"
+    ],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": [
+    "node_modules",
+    ".vscode-test"
+  ]
+}


### PR DESCRIPTION
This commit introduces a new VS Code extension called "Dart Log Remover".

Features:
- Removes `print()` and `dart:developer log()` statements from the active Dart file.
- Provides a "Dry-run: Show Logs to be Removed" command that lists statements for removal in an output channel without modifying the file.
- Regex-based detection for log statements.
- Basic unit evaluations for core logic (regex matching and edit generation).
- Includes a README.md with installation and usage instructions.

The extension is activated via commands found in the Command Palette:
- "Remove Log Statements"
- "Dry-run: Show Logs to be Removed"

Output: